### PR TITLE
digits shouldn't be shorter than 2 characters long

### DIFF
--- a/baseconv.py
+++ b/baseconv.py
@@ -88,6 +88,8 @@ class BaseConverter(object):
         self.digits = digits
         if sign in self.digits:
             raise ValueError('sign character found in converter base digits')
+        if len(self.digits) <= 1:
+            raise ValueError('converter base digits length too short')
 
     def __repr__(self):
         data = (self.__class__.__name__, self.digits, self.sign)

--- a/baseconv.py
+++ b/baseconv.py
@@ -52,6 +52,11 @@ Example usage::
 
 Exceptions::
 
+  >>> BaseConverter('')
+  Traceback (most recent call last):
+      ...
+  ValueError: converter base digits length too short
+
   >>> BaseConverter(digits='xyz-._', sign='-')
   Traceback (most recent call last):
       ...


### PR DESCRIPTION
Also, prevents an infinite loop when trying to encode with a base 1 BaseConverter.

Example code that infinitely loops:

```python3
from baseconv import BaseConverter
base1 = BaseConverter('0')
base1.encode(5)
```