### PR TITLE
Add Python version classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
         'License :: OSI Approved :: Python Software Foundation License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     py_modules=['baseconv'],


### PR DESCRIPTION
This will help projects that use this package migrate from Python 2 to Python 3 since I believe tools like https://pypi.org/project/caniusepython3/ rely on this classifier to detect dependency readiness.

Based on [.travis.yml](https://github.com/semente/python-baseconv/blob/d9831a527c2a55f4514a1f32ea12fae755972d42/.travis.yml#L3-L6) it seems this package currently supports both Python 3 and 2.7.